### PR TITLE
draft:  add exception middleware

### DIFF
--- a/faststream/broker/middlewares/exception.py
+++ b/faststream/broker/middlewares/exception.py
@@ -1,0 +1,30 @@
+from .base import BaseMiddleware
+from typing import Coroutine, Optional, TypeVar, Callable
+
+E = TypeVar("E", bound=Exception)
+
+
+class ExceptionMiddleware(BaseMiddleware):
+    exc_handlers = dict()
+
+    def __init__(self, exc_handlers: Optional[dict[E, Coroutine]]) -> None:
+        if not exc_handlers:
+            exc_handlers = dict()
+        self._exc_handlers = exc_handlers
+
+    @classmethod
+    def add_handler(cls, exc: E) -> Callable:
+        def wrapper(func: Coroutine) -> None:
+            cls.exc_handlers[exc] = func
+        return wrapper
+
+    async def after_consume(self, err: Optional[Exception]) -> None:
+        if err:
+            handler = self.exc_handlers.get(type(err))
+            if handler:
+                await handler(err)
+            else:
+                raise err
+
+
+add_exception_handler = ExceptionMiddleware.add_handler


### PR DESCRIPTION
Usage example:
```
from faststream import FastStream, Depends
from faststream.rabbit import RabbitBroker
from faststream.broker.middlewares.exception import add_exception_handler, ExceptionMiddleware


@add_exception_handler(ValueError)
async def handle_value_exception(exc: ValueError):
    print(exc)


broker = RabbitBroker("amqp://user:pass@host:port/", middlewares=(ExceptionMiddleware, ))
app = FastStream(broker)


@app.after_startup
async def test_publish():
    await broker.publish("test_message", queue="in-queue")


@broker.subscriber("in-queue")
async def handle_msg(msg: str) -> str:
    raise ValueError(2)
    return msg

```